### PR TITLE
Hotfix/92 팀 중복 처리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.easyhz.patchnote"
         minSdk = 26
         targetSdk = 35
-        versionCode = 19
-        versionName = "2.2.2"
+        versionCode = 20
+        versionName = "2.2.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/easyhz/patchnote/data/mapper/sign/UserMapper.kt
+++ b/app/src/main/java/com/easyhz/patchnote/data/mapper/sign/UserMapper.kt
@@ -12,8 +12,8 @@ fun User.toRequest() = SaveUserRequest(
     id = id,
     name = name,
     phone = phone,
-    teamIds = teamIds,
-    teamJoinDates = teamJoinDates.map { it.toRequest() }
+    teamIds = teamIds.removeDuplicate(),
+    teamJoinDates = teamJoinDates.removeDuplicateTeamId().map { it.toRequest() },
 )
 
 fun UserResponse.toModel(
@@ -37,3 +37,10 @@ private fun TeamJoinDate.toRequest() = TeamJoinDateData(
     teamId = teamId,
     joinDate = DateFormatUtil.localDateTimeToTimestamp(joinDate)
 )
+
+private fun <T> List<T>.removeDuplicate(): List<T> {
+    return LinkedHashSet(this).toList()
+}
+
+private fun List<TeamJoinDate>.removeDuplicateTeamId(): List<TeamJoinDate> =
+    this.distinctBy { it.teamId }

--- a/app/src/test/java/com/easyhz/patchnote/data/mapper/UserMapperTest.kt
+++ b/app/src/test/java/com/easyhz/patchnote/data/mapper/UserMapperTest.kt
@@ -1,0 +1,27 @@
+package com.easyhz.patchnote.data.mapper
+
+import com.easyhz.patchnote.core.model.user.TeamJoinDate
+import com.easyhz.patchnote.core.model.user.User
+import com.easyhz.patchnote.data.mapper.sign.toRequest
+import org.junit.Test
+
+class UserMapperTest {
+    @Test
+    fun `팀 아이디 중복이 있는지 확인`() {
+        val user = User.Empty.copy(
+            teamIds = listOf("team1", "team2", "team1", "team2"),
+            teamJoinDates = listOf(
+                TeamJoinDate.create("team1"),
+                TeamJoinDate.create("team2"),
+                TeamJoinDate.create("team1"),
+                TeamJoinDate.create("team2"),
+            )
+        )
+
+        val result = user.toRequest()
+
+        assert(result.teamIds.size == 2)
+        assert(result.teamJoinDates.size == 2)
+        assert(result.teamIds.last() == result.teamJoinDates.last().teamId)
+    }
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #92 

## 📌 Tasks

-  팀 중복처리

## 📝 Details

- 팀이 이미 있으면 중복 처리 안되게했음
 -> 사용자 경험을 위해 이미 가입한 팀이라고 다이얼로그 필요할듯

## 📚 Remarks

> Points or opinions to share teams

- 
- 