### PR TITLE
Fix/107 하자 수정 시 현장 디코딩 안되는 이슈 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.easyhz.patchnote"
         minSdk = 26
         targetSdk = 35
-        versionCode = 28
-        versionName = "2.3.5"
+        versionCode = 29
+        versionName = "2.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/easyhz/patchnote/ui/screen/defect/edit/EditViewModel.kt
+++ b/app/src/main/java/com/easyhz/patchnote/ui/screen/defect/edit/EditViewModel.kt
@@ -77,9 +77,9 @@ abstract class EditViewModel(
 
     private fun initData() {
         val defectItemArgs: String? = savedStateHandle["defectItem"]
-        val defectItem = serializableHelper.deserialize(defectItemArgs, DefectItem::class.java) ?: return navigateUp()
+        val defectItem = serializableHelper.deserialize(defectItemArgs, DefectItem::class.java)?.toDecode() ?: return navigateUp()
 
-        reduce { copy(defectItem = defectItem.toDecode(), entryContent = defectItem.beforeDescription, entryItem = entryItem) }
+        reduce { copy(defectItem = defectItem, entryContent = defectItem.beforeDescription, entryItem = entryItem) }
         setUp(defectItem)
     }
 


### PR DESCRIPTION
## 🚀 Related Issue

close: #107 

## 📌 Tasks

- 하자 수정 시 디코딩 안되는 이슈 수정했습니다.

## 📝 Details

- 현장 뿐만 아니라 모든 데이터가 ui 상으로 디코딩이 안되고 있었습니다.

## 📚 Remarks

> Points or opinions to share teams

- 
- 