### PR TITLE
Hotfix/109 접수화면에서 접수 취소 시 로딩 인디케이터가 보이는 이슈

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.easyhz.patchnote"
         minSdk = 26
         targetSdk = 35
-        versionCode = 29
-        versionName = "2.3.6"
+        versionCode = 30
+        versionName = "2.3.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/easyhz/patchnote/ui/screen/defect/defectEntry/DefectEntryViewModel.kt
+++ b/app/src/main/java/com/easyhz/patchnote/ui/screen/defect/defectEntry/DefectEntryViewModel.kt
@@ -130,7 +130,6 @@ class DefectEntryViewModel @Inject constructor(
         clearFocus()
         if (!isValidDefect(invalidEntry)) return@launch
         if (!isValidImage()) return@launch
-        setLoading(true)
         reduce { copy(entryItem = entryItem, isShowEntryDialog = true) }
     }
 


### PR DESCRIPTION
## 🚀 Related Issue

close: #109 

## 📌 Tasks

- 접수화면에서 접수 취소 시 로딩 인디케이터가 보이는 이슈

## 📝 Details

- 접수 화면 로딩 타이밍 수정했스빈다.

## 📚 Remarks

> Points or opinions to share teams

- 
- 